### PR TITLE
Build proper exception

### DIFF
--- a/native/deno_rider/src/error.rs
+++ b/native/deno_rider/src/error.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, rustler::NifStruct)]
+#[derive(Debug, rustler::NifException)]
 #[module = "DenoRider.Error"]
 pub struct Error {
     pub message: Option<std::string::String>,

--- a/test/deno_rider_test.exs
+++ b/test/deno_rider_test.exs
@@ -133,10 +133,15 @@ defmodule DenoRiderTest do
 
     assert {:ok, nil} = stop_runtime(runtime) |> Task.await()
 
-    assert {:error, %Error{name: :dead_runtime_error}} =
+    assert {:error, %Error{name: :dead_runtime_error} = error} =
              eval("1 + 2", blocking: true, runtime: runtime)
 
-    assert {:error, %Error{name: :dead_runtime_error}} = stop_runtime(runtime) |> Task.await()
+    assert Exception.message(error) == "dead_runtime_error"
+
+    assert {:error, %Error{name: :dead_runtime_error} = error} =
+             stop_runtime(runtime) |> Task.await()
+
+    assert Exception.message(error) == "dead_runtime_error"
   end
 
   @tag :panic
@@ -145,11 +150,15 @@ defmodule DenoRiderTest do
 
     # We currently don't support returning symbols, so we use that to make the
     # worker thread panic.
-    assert {:error, %Error{name: :execution_error}} =
+    assert {:error, %Error{name: :execution_error} = error} =
              eval("Symbol('foo')", blocking: true, runtime: runtime)
 
-    assert {:error, %Error{name: :dead_runtime_error}} =
+    assert Exception.message(error) == "execution_error"
+
+    assert {:error, %Error{name: :dead_runtime_error} = error} =
              eval("1 + 2", blocking: true, runtime: runtime)
+
+    assert Exception.message(error) == "dead_runtime_error"
   end
 
   @tag :benchmark

--- a/test/deno_rider_test.exs
+++ b/test/deno_rider_test.exs
@@ -105,41 +105,27 @@ defmodule DenoRiderTest do
   end
 
   test "eval with syntax error" do
-    assert(
-      {
-        :error,
-        %Error{
-          message: "Uncaught SyntaxError: Unexpected token ')'\n    at <anon>:1:1",
-          name: :execution_error
-        }
-      } = eval(")", blocking: true)
-    )
+    assert {:error, %Error{name: :execution_error} = error} = eval(")", blocking: true)
+
+    assert Exception.message(error) ==
+             "execution_error: Uncaught SyntaxError: Unexpected token ')'\n    at <anon>:1:1"
 
     assert {:ok, 3} = eval("1 + 2", blocking: true)
   end
 
   test "main module with syntax error" do
-    assert(
-      {
-        :error,
-        %Error{
-          message: "Uncaught SyntaxError: Unexpected token ')'\n    at file://" <> _,
-          name: :execution_error
-        }
-      } = start_runtime(main_module_path: "test/support/syntax_error.js") |> Task.await()
-    )
+    assert {:error, %Error{name: :execution_error} = error} =
+             start_runtime(main_module_path: "test/support/syntax_error.js") |> Task.await()
+
+    assert Exception.message(error) =~
+             "execution_error: Uncaught SyntaxError: Unexpected token ')'\n    at file:///"
   end
 
   test "non-existent main module" do
-    assert(
-      {
-        :error,
-        %Error{
-          message: "Failed to load file:///foo",
-          name: :execution_error
-        }
-      } = start_runtime(main_module_path: "/foo") |> Task.await()
-    )
+    assert {:error, %Error{name: :execution_error} = error} =
+             start_runtime(main_module_path: "/foo") |> Task.await()
+
+    assert Exception.message(error) == "execution_error: Failed to load file:///foo"
   end
 
   test "stop runtime" do


### PR DESCRIPTION
When an error occurred, a simple struct was being returned where I believe an exception should be returned instead. Updates the `error.rs` to return an exception.