### PR TITLE
Make it possible to call Elixir from JavaScript

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,6 +1732,7 @@ dependencies = [
  "rustler",
  "serde_json",
  "serde_v8",
+ "slab",
  "sys_traits",
  "tokio",
 ]

--- a/README.md
+++ b/README.md
@@ -63,20 +63,40 @@ See [`eval/1`](https://hexdocs.pm/deno_rider/DenoRider.html#eval/1) and
 [`eval/2`](https://hexdocs.pm/deno_rider/DenoRider.html#eval/2) for different
 ways of running JavaScript code.
 
-If you don't want to run DenoRider as a process, you can manage the runtime
-manually:
+If you don't want to run DenoRider as a linked process, you can manage the
+process manually:
 
 ```elixir
-iex> {:ok, runtime} = DenoRider.start_runtime() |> Task.await()
-{:ok, %DenoRider.Runtime{reference: #Reference<0.328177905.1027473408.14690>}}
-iex> DenoRider.eval("1 + 2", runtime: runtime) |> Task.await()
+iex> {:ok, pid} = DenoRider.start()
+{:ok, #PID<0.192.0>}
+iex> DenoRider.eval("1 + 2", pid: pid)
 {:ok, 3}
-iex> DenoRider.stop_runtime(runtime) |> Task.await()
-{:ok, nil}
+iex> DenoRider.stop(pid: pid)
+:ok
 ```
 
 Read the [full documentation](https://hexdocs.pm/deno_rider/DenoRider.html) for
 more information.
+
+### JavaScript API
+
+Inside the JavaScript runtime, DenoRider provides a JavaScript API under the
+global object `DenoRider`. Currently, `DenoRider.apply` is the only available
+function.
+
+#### `DenoRider.apply`
+
+Call an Elixir or Erlang function from JavaScript. Similarly to
+[`Kernel.apply/3`](https://hexdocs.pm/elixir/Kernel.html#apply/3), it take a
+module, a function and an array of arguments:
+
+```javascript
+await DenoRider.apply("Kernel", "+", [1, 2]); // 3
+await DenoRider.apply(":math", "floor", [3.14]); // 3
+```
+
+It returns a promise that resolves with the value returned from the Elixir
+function. Note that the return value needs to be JSON encodable.
 
 ## FAQ
 

--- a/lib/deno_rider.ex
+++ b/lib/deno_rider.ex
@@ -6,13 +6,82 @@ defmodule DenoRider do
   alias DenoRider.Runtime
 
   @doc """
+  Start a DenoRider process without any main module.
+
+  See `start/1` for more information.
+
+  ## Examples
+
+      iex> {:ok, pid} = DenoRider.start()
+      iex> DenoRider.eval("1 + 2", pid: pid)
+      {:ok, 3}
+  """
+  @spec start() :: GenServer.on_start()
+  def start do
+    start([])
+  end
+
+  @doc """
   Start a DenoRider process.
 
   ## Options
 
-    * `:name` - The name of the process.
+    * `:main_module_path` - Path to the main JavaScript module. The default is
+      to start the runtime without a main module.
 
-  See `start_runtime/1` for more options.
+  ## Examples
+
+      iex> DenoRider.start(main_module_path: "path/to/main.js")
+  """
+  @spec start() :: GenServer.on_start()
+  def start(opts) do
+    GenServer.start(__MODULE__, opts)
+  end
+
+  @doc """
+  Same as `stop/1`, but it assumes that there is a process with the name
+  `DenoRider` (the default if you don't provide a name to `start_link/1`).
+  """
+  @spec stop() :: :ok
+  def stop do
+    stop([])
+  end
+
+  @doc """
+  Stop a DenoRider process.
+
+  ## Options
+
+    * `:name` - The name of the DenoRider process. The default is
+      `DenoRider`. Can't be provided if `:pid` is provided.
+    * `:pid` - The pid of the DenoRider process. Can't be provided if `:name` is
+      provided.
+    * `:reason` - See `GenServer.stop/3`.
+    * `:timeout` - See `GenServer.stop/3`.
+
+  ## Examples
+
+      iex> {:ok, pid} = DenoRider.start()
+      iex> DenoRider.stop(pid: pid)
+      :ok
+  """
+  @spec stop(Keyword.t()) :: :ok
+  def stop(opts) do
+    GenServer.stop(
+      Keyword.get(opts, :pid) || Keyword.get(opts, :name, __MODULE__),
+      Keyword.get(opts, :reason, :normal),
+      Keyword.get(opts, :timeout, :infinity)
+    )
+  end
+
+  @doc """
+  Start a DenoRider process linked to the current process.
+
+  ## Options
+
+    * `:name` - The name of the process. The default is `DenoRider`.
+
+  See `start/1` for more options.
 
   ## Examples
 
@@ -20,12 +89,11 @@ defmodule DenoRider do
       iex> DenoRider.eval("1 + 2", name: MyApp.DenoRider)
       {:ok, 3}
   """
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
   def start_link(opts) do
-    {:ok, runtime} = Keyword.take(opts, [:main_module_path]) |> start_runtime() |> Task.await()
-
     GenServer.start_link(
       __MODULE__,
-      runtime,
+      Keyword.take(opts, [:main_module_path]),
       name: Keyword.get(opts, :name, __MODULE__)
     )
   end
@@ -45,7 +113,8 @@ defmodule DenoRider do
   end
 
   @doc """
-  Run the given JavaScript code and return the result.
+  Run the given JavaScript code and return the result. If a promise is returned,
+  it will be awaited.
 
   ## Options
 
@@ -57,10 +126,9 @@ defmodule DenoRider do
       this to `true` if you need the performance boost and the execution stays
       below 1 millisecond or so. The default is `false`.
     * `:name` - The name of the DenoRider process. The default is
-      `DenoRider`. Can't be provided if `:runtime` is provided.
-    * `:runtime` - A runtime from `start_runtime/1`. If `:runtime` is provided,
-      `eval/2` will return a `Task` that finishes when the JavaScript exection
-      finishes. Can't be provided if `:name` is provided.
+      `DenoRider`. Can't be provided if `:pid` is provided.
+    * `:pid` - The pid of the DenoRider process. Can't be provided if `:name` is
+      provided.
 
   ## Examples
 
@@ -74,128 +142,180 @@ defmodule DenoRider do
       iex> DenoRider.eval("1 + 2", name: :foo)
       {:ok, 3}
 
-      iex> {:ok, runtime} = DenoRider.start_runtime() |> Task.await()
-      iex> DenoRider.eval("1 + 2", runtime: runtime) |> Task.await()
+      iex> {:ok, pid} = DenoRider.start()
+      iex> DenoRider.eval("1 + 2", pid: pid)
+      {:ok, 3}
   """
-  @spec eval(binary(), Keyword.t()) :: {:ok, term()} | {:error, Error.t()} | Task.t()
+  @spec eval(binary(), Keyword.t()) :: {:ok, term()} | {:error, Error.t()}
   def eval(code, opts) do
-    if runtime = Keyword.get(opts, :runtime) do
-      if Keyword.get(opts, :blocking, false) do
-        with {:ok, json} <- Native.eval_blocking(runtime.reference, code) do
-          Jason.decode(json)
-        end
-      else
-        # credo:disable-for-next-line Credo.Check.Refactor.Nesting
-        Task.async(fn ->
-          :ok = Native.eval(nil, runtime.reference, code)
-
-          receive do
-            {:eval_reply, nil, {:ok, json}} ->
-              Jason.decode(json)
-
-            {:eval_reply, nil, error} ->
-              error
-          end
-        end)
-      end
-    else
-      Keyword.get(opts, :name, __MODULE__)
-      |> GenServer.call({:eval, code, opts})
-    end
+    GenServer.call(
+      Keyword.get(opts, :pid) || Keyword.get(opts, :name, __MODULE__),
+      {:eval, code, opts}
+    )
   end
 
   @doc """
-  Start a JavaScript runtime and return a `Task` that finishes when runtime has
-  started.
-
-  ## Options
-
-    * `:main_module_path` - Path to the main JavaScript module. The default is to start the runtime with an empty main module.
-
-  ## Examples
-
-      iex> DenoRider.start_runtime() |> Task.await()
+  Same as `eval/1`, but raises if the result isn't successful.
   """
-  @spec start_runtime(Keyword.t()) :: Task.t()
-  def start_runtime(opts \\ []) do
-    Task.async(fn ->
-      :ok =
-        Keyword.get(opts, :main_module_path, "#{Application.app_dir(:deno_rider)}/priv/main.js")
-        |> Native.start_runtime()
-
-      receive do
-        {:ok, reference} ->
-          {:ok, %Runtime{reference: reference}}
-
-        error ->
-          error
-      end
-    end)
+  @spec eval!(binary()) :: term()
+  def eval!(code) do
+    {:ok, result} = eval(code)
+    result
   end
 
   @doc """
-  Stop a JavaScript runtime and return a `Task` that finishes when runtime has
-  stopped.
-
-  ## Examples
-
-      iex> {:ok, runtime} = DenoRider.start_runtime() |> Task.await()
-      iex> DenoRider.stop_runtime(runtime) |> Task.await()
+  Same as `eval/2`, but raises if the result isn't successful.
   """
-  @spec stop_runtime(Runtime.t()) :: Task.t()
-  def stop_runtime(runtime) do
-    Task.async(fn ->
-      :ok = Native.stop_runtime(runtime.reference)
-
-      receive do
-        :ok ->
-          {:ok, nil}
-
-        error ->
-          error
-      end
-    end)
+  @spec eval!(binary(), Keyword.t()) :: term()
+  def eval!(code, opts) do
+    {:ok, result} = eval(code, opts)
+    result
   end
 
   @impl GenServer
-  def init(initial_arg) do
-    {:ok, initial_arg}
+  def init(opts) do
+    pid = self()
+
+    result =
+      Task.async(fn ->
+        :ok =
+          Native.start_runtime(
+            pid,
+            Keyword.get(
+              opts,
+              :main_module_path,
+              "#{Application.app_dir(:deno_rider)}/priv/main.js"
+            )
+          )
+
+        receive do
+          {:ok, reference} ->
+            {:ok, %Runtime{reference: reference}}
+
+          error ->
+            error
+        end
+      end)
+      |> Task.await()
+
+    case result do
+      {:ok, _} = result ->
+        result
+
+      {:error, error} ->
+        {:stop, error}
+    end
   end
 
   @impl GenServer
   def handle_call({:eval, code, opts}, from, state) do
     if Keyword.get(opts, :blocking, false) do
-      {
-        :reply,
-        with {:ok, json} <- Native.eval_blocking(state.reference, code) do
-          Jason.decode(json)
-        end,
-        state
-      }
+      case Native.eval_blocking(state.reference, code) do
+        {:ok, json} ->
+          {:reply, {:ok, Jason.decode!(json)}, state}
+
+        {:error, %Error{name: :dead_runtime_error}} ->
+          {:stop, {:shutdown, :dead_runtime_error}, state}
+
+        error ->
+          {:reply, decode_promise_rejection(error), state}
+      end
     else
-      Native.eval(from, state.reference, code)
+      :ok = Native.eval(from, state.reference, code)
       {:noreply, state}
     end
+  end
+
+  @impl GenServer
+  def handle_info({:apply, application_id, module, function_name, args}, state) do
+    decoded_args = Jason.decode!(args)
+
+    result =
+      with {:ok, decoded_module} <- to_module(module),
+           {:ok, decoded_function_name} <- to_atom(function_name),
+           :ok <-
+             function_exists?(decoded_module, decoded_function_name, Enum.count(decoded_args)),
+           result <- apply(decoded_module, decoded_function_name, decoded_args),
+           {:ok, encoded_result} <- encode_json(result) do
+        {:ok, encoded_result}
+      else
+        {:error, error} ->
+          {:error, Jason.encode!(error)}
+      end
+
+    {:ok, {}} =
+      Native.apply_reply(
+        state.reference,
+        application_id,
+        result
+      )
+
+    {:noreply, state}
   end
 
   @impl GenServer
   def handle_info({:eval_reply, from, result}, state) do
     case result do
       {:ok, json} ->
-        GenServer.reply(from, Jason.decode(json))
+        GenServer.reply(from, {:ok, Jason.decode!(json)})
         {:noreply, state}
 
       {:error, %Error{name: :dead_runtime_error}} ->
         {:stop, {:shutdown, :dead_runtime_error}, state}
 
       error ->
-        GenServer.reply(from, error)
+        GenServer.reply(from, decode_promise_rejection(error))
         {:noreply, state}
     end
   end
 
   @impl GenServer
   def terminate(_, state) do
-    stop_runtime(state)
+    :ok = Native.stop_runtime(state.reference)
+  end
+
+  defp decode_promise_rejection(error) do
+    case error do
+      {:error, %Error{name: :promise_rejection} = e} ->
+        {:error, %{e | value: Jason.decode!(e.value)}}
+
+      _ ->
+        error
+    end
+  end
+
+  defp encode_json(value) do
+    case Jason.encode(value) do
+      {:ok, _} = result ->
+        result
+
+      {:error, error} ->
+        {:error, "Could not convert to JSON: #{inspect(error.value)}"}
+    end
+  end
+
+  defp function_exists?(module, function_name, arity) do
+    if function_exported?(module, function_name, arity) do
+      :ok
+    else
+      {:error, "No such function: #{module}.#{function_name}/#{arity}"}
+    end
+  end
+
+  defp to_module(string) do
+    case string do
+      ":" <> name ->
+        to_atom(name)
+
+      _ ->
+        to_atom("Elixir.#{string}")
+    end
+  end
+
+  defp to_atom(string) do
+    {:ok, String.to_existing_atom(string)}
+  rescue
+    ArgumentError ->
+      {:error, "No existing atom: #{string}"}
   end
 end

--- a/lib/deno_rider/error.ex
+++ b/lib/deno_rider/error.ex
@@ -5,12 +5,13 @@ defmodule DenoRider.Error do
 
   @type t :: %__MODULE__{}
 
-  defexception [:message, :name]
+  defexception [:message, :name, :value]
 
   def exception(opts) do
     %__MODULE__{
       message: Keyword.get(opts, :message),
-      name: Keyword.fetch!(opts, :name)
+      name: Keyword.fetch!(opts, :name),
+      value: Keyword.get(opts, :value)
     }
   end
 

--- a/lib/deno_rider/native.ex
+++ b/lib/deno_rider/native.ex
@@ -16,11 +16,13 @@ defmodule DenoRider.Native do
     ],
     version: version
 
-  def start_runtime(_main_module_path), do: :erlang.nif_error(:nif_not_loaded)
+  def start_runtime(_pid, _main_module_path), do: :erlang.nif_error(:nif_not_loaded)
 
   def stop_runtime(_reference), do: :erlang.nif_error(:nif_not_loaded)
 
   def eval(_from, _reference, _code), do: :erlang.nif_error(:nif_not_loaded)
 
   def eval_blocking(_reference, _code), do: :erlang.nif_error(:nif_not_loaded)
+
+  def apply_reply(_reference, _application_id, _result), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/deno_rider/Cargo.toml
+++ b/native/deno_rider/Cargo.toml
@@ -6,6 +6,7 @@ deno_runtime = "0.194.0"
 rustler = "0.36.0"
 serde_json = "1.0.133"
 serde_v8 = "0.239.0"
+slab = "0.4.9"
 sys_traits = "0.1.7"
 tokio = "1.41.1"
 

--- a/native/deno_rider/extension/main.js
+++ b/native/deno_rider/extension/main.js
@@ -1,0 +1,29 @@
+import {randomUUID} from "node:crypto";
+
+import {op_apply} from "ext:core/ops";
+
+globalThis.DenoRider = {
+  _applications: {},
+  _handleApplicationResult: (applicationId, result) => {
+    DenoRider._applications[applicationId].resolve(result);
+    delete DenoRider._applications[applicationId];
+  },
+  _runtimeId: null,
+  apply: (module, functionName, args) => {
+    if (typeof module !== "string") {
+      throw new Error(`Not a string: ${module}`);
+    }
+    if (typeof functionName !== "string") {
+      throw new Error(`Not a string: ${functionName}`);
+    }
+    if (!Array.isArray(args)) {
+      throw new Error(`Not an array: ${args}`);
+    }
+    const applicationId = randomUUID();
+    const promise = new Promise((resolve, reject) => {
+      DenoRider._applications[applicationId] = {reject, resolve};
+    });
+    op_apply(DenoRider._runtimeId, applicationId, module, functionName, JSON.stringify(args));
+    return promise;
+  },
+};

--- a/native/deno_rider/src/atoms.rs
+++ b/native/deno_rider/src/atoms.rs
@@ -1,8 +1,10 @@
 rustler::atoms! {
+    apply,
     conversion_error,
     dead_runtime_error,
     eval_reply,
     error,
     execution_error,
+    promise_rejection,
     ok,
 }

--- a/native/deno_rider/src/error.rs
+++ b/native/deno_rider/src/error.rs
@@ -3,4 +3,5 @@
 pub struct Error {
     pub message: Option<std::string::String>,
     pub name: rustler::Atom,
+    pub value: Option<std::string::String>,
 }

--- a/native/deno_rider/src/runtimes.rs
+++ b/native/deno_rider/src/runtimes.rs
@@ -1,0 +1,7 @@
+use slab::Slab;
+use std::sync::{Mutex, OnceLock};
+
+pub fn get() -> &'static Mutex<Slab<rustler::LocalPid>> {
+    static RUNTIMES: OnceLock<Mutex<Slab<rustler::LocalPid>>> = OnceLock::new();
+    RUNTIMES.get_or_init(|| Mutex::new(Slab::new()))
+}

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -1,0 +1,7 @@
+import http from "node:http";
+
+http.createServer(async (_, response) => {
+  const result = await DenoRider.apply("Kernel", "+", [1, 2]);
+  response.writeHead(200);
+  response.end(`Result: ${result}`);
+}).listen(3000);


### PR DESCRIPTION
* A JavaScript API, `DenoRider.apply`, is introduced for calling Elixir from JavaScript.
* Promises returned in `DenoRider.eval` are resolved before being returned to Elixir-land.
* The JavaScript runtime now always gets a dedicated process, which means that `DenoRider.start_runtime` and `DenoRider.stop_runtime` are removed. Instead, `DenoRider.start` and `DenoRider.stop` are introduced.
* `DenoRider.eval!` is introduced, which raises if the evaluation isn't successful.

This solves #5.