### PR TITLE
Upgrade `deno` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "cargo"
+    directory: "/native/deno_rider"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/native/deno_rider/Cargo.lock
+++ b/native/deno_rider/Cargo.lock
@@ -233,6 +233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -966,7 +972,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "serde",
- "sourcemap 9.1.2",
+ "sourcemap 9.3.2",
  "swc_atoms",
  "swc_common",
  "swc_config",
@@ -996,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "deno_broadcast_channel"
-version = "0.180.0"
+version = "0.184.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83edf054825c9840a058e5ad24134a986991a7e23abfd3f266eebd60ac9212ef"
+checksum = "33db5dacb54c6fda4c5ea4103c5687b76a51202343379af8b21120ba9d20f3c2"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1010,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cache"
-version = "0.118.0"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "012983d6e32498f75134c074760aeae054d8a081972db848e796da4135f229b7"
+checksum = "e0daca6ec4e6142a994d38e7bc587dda7948fa00e6194b671a5d4340f5a918a3"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1026,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cache_dir"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73ed17f285731a23df9779ca1e0e721de866db6776ed919ebd9235e0a107c4c"
+checksum = "27429da4d0e601baaa41415a43468d49a586645d13497f12e8a9346f9f6b1347"
 dependencies = [
  "async-trait",
  "base32",
@@ -1041,7 +1047,7 @@ dependencies = [
  "deno_media_type",
  "deno_path_util",
  "http 1.2.0",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "log",
  "once_cell",
  "parking_lot",
@@ -1055,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "deno_canvas"
-version = "0.55.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe8909e98d3e8a9160e76563580c7535e7e2aebc4e8315b26e04cea49d912bd"
+checksum = "35ca8f93d60d96d6f6cb0da632303afb98567accf07d9b6f8d2ef88617589d9e"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1069,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a47412627aa0d08414eca0e8329128013ab70bdb2cdfdc5456c2214cf24c8f"
+checksum = "08fe512a72c4300bd997c6849450a1f050da0c909a2a4fbdc44891647392bacf"
 dependencies = [
  "boxed_error",
  "capacity_builder 0.5.0",
@@ -1082,7 +1088,7 @@ dependencies = [
  "glob",
  "ignore",
  "import_map",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "jsonc-parser",
  "log",
  "percent-encoding",
@@ -1096,18 +1102,18 @@ dependencies = [
 
 [[package]]
 name = "deno_console"
-version = "0.186.0"
+version = "0.190.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f3708a2df0d69084294bcd259441c70d0556a709c21ddf9595effdee394441"
+checksum = "94352b8d75c288a26ef748ad0ddae07e181109374a02c547850f96eef76b5389"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.330.0"
+version = "0.336.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd38bbbd68ed873165ccb630322704b44140d3a8c8d50f898beac4d1a8a3358c"
+checksum = "fdd50476c4325d5fa52bb906804a1e35b127d2a1dcf674e3447b53dcf25525bf"
 dependencies = [
  "anyhow",
  "az",
@@ -1120,9 +1126,10 @@ dependencies = [
  "deno_core_icudata",
  "deno_error",
  "deno_ops",
+ "deno_path_util",
  "deno_unsync",
  "futures",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "libc",
  "memoffset",
  "parking_lot",
@@ -1149,9 +1156,9 @@ checksum = "fe4dccb6147bb3f3ba0c7a48e993bfeb999d2c2e47a81badee80e2b370c8d695"
 
 [[package]]
 name = "deno_cron"
-version = "0.66.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7483779abb38ac203155a52b3cdb2b9401a62f628ee6c840f70d7137dc8956"
+checksum = "e8ec283bef14bcf655b209619766bdeab67f2a5e093991cca73f5d502f7bf6e8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1165,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.200.0"
+version = "0.204.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744e9be2aa5353a06d5d289f52f73b84c52433624987728829526d66693a9deb"
+checksum = "4f0493142a437e49b46aa8e08d715942076ff48c3cb776f0b015b4224ed0d37a"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1205,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "deno_error"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da6a58de6932a96f84e133c072fd3b525966ee122a71f3efd48bbff2eed5ac"
+checksum = "9c23dbc46d5804814b08b4675838f9884e3a52916987ec5105af36d42f9911b5"
 dependencies = [
  "deno_error_macro",
  "libc",
@@ -1219,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "deno_error_macro"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46351dff93aed2039407c91e2ded2a5591e42d2795ab3d111288625bb710d3d2"
+checksum = "babccedee31ce7e57c3e6dff2cb3ab8d68c49d0df8222fe0d11d628e65192790"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1230,15 +1237,16 @@ dependencies = [
 
 [[package]]
 name = "deno_fetch"
-version = "0.210.0"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419bb3b18e9a1d3d0752f689d9cb51649adf687ab2c7af9f4a09ba9b818867a6"
+checksum = "3df032ca1f7f06a5cc459189b960793f64d415ddc9f59f262e0ad5059865002d"
 dependencies = [
  "base64 0.21.7",
  "bytes",
  "data-url",
  "deno_core",
  "deno_error",
+ "deno_fs",
  "deno_path_util",
  "deno_permissions",
  "deno_tls",
@@ -1268,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ffi"
-version = "0.173.0"
+version = "0.177.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9f0b5d53bc0708e3f3ebff5b8c853d67db664dc6a476a6905193a5fb8713a"
+checksum = "bfbdc4e55c79ec1bc8a3ac72313e6f70d76340222f1e50c5c91e050296f83544"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1291,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "deno_fs"
-version = "0.96.0"
+version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0795cc78903e13496c0115406b35e8ab663de2198720e14ca2861fda7e42793"
+checksum = "c82f79b71403b93b248727a89746026104b3a5ac1d82e79a02af6fa8e8487666"
 dependencies = [
  "async-trait",
  "base32",
@@ -1317,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "deno_http"
-version = "0.184.0"
+version = "0.188.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a254681750ef7368563f3983672e8e280c7ecb63d1152999e8f2c28f31b92cf"
+checksum = "d0b7e7a3bcac31ebd4677a96318003a98f0fda4613f6ba6d7f5ba57928727191"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -1356,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "deno_io"
-version = "0.96.0"
+version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e55124bd2bcb9c91aa02bef01769f9a7fd5a0b700dc3e446a6a13612ae41fab"
+checksum = "1e72489fe0dcada08047611d1ab92db1baebf7b606ab7c78790f622ecb30e22b"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1380,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "deno_kv"
-version = "0.94.0"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4d1860ca11d7642325a8a0ef7b735caeb63da8d9cb0771a95267130c51a3ea"
+checksum = "b0e3930d0195a3350c05eb9a4bc619ec598ea84ad8bdb9b6c3e4bef798e7cf34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1438,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "deno_napi"
-version = "0.117.0"
+version = "0.121.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b9a05048d2d75fe0ff2b3288e270812e8607698a0dedd57df0fd0fadbe2c7d"
+checksum = "13f30bf147cc46dba87e3088d037cf99a2845ead1138033d3b346178cb781558"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1468,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "deno_net"
-version = "0.178.0"
+version = "0.182.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96bbe475789cc1abeb0e9e63e2d0167c2fc82ed08be90c319991181e5ea43e2"
+checksum = "ab869063cbfe428a707511835865d55247886eb175659e538af4d5096c3d4d9d"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1489,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "deno_node"
-version = "0.124.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d17408536127560304c4622c77c9b34521a89deca5f680c8619180ff025a05"
+checksum = "9638e803a668b0a5793ff94c9b2e82c54a05d9fc510901e9f3093d2d63dbdaab"
 dependencies = [
  "aead-gcm-stream",
  "aes",
@@ -1503,17 +1511,18 @@ dependencies = [
  "bytes",
  "cbc",
  "const-oid",
+ "ctr",
  "data-encoding",
  "deno_core",
  "deno_error",
  "deno_fetch",
  "deno_fs",
  "deno_io",
- "deno_media_type",
  "deno_net",
  "deno_package_json",
  "deno_path_util",
  "deno_permissions",
+ "deno_process",
  "deno_whoami",
  "der",
  "digest",
@@ -1522,7 +1531,7 @@ dependencies = [
  "ecdsa",
  "ed25519-dalek",
  "elliptic-curve",
- "errno 0.2.8",
+ "errno",
  "faster-hex",
  "h2 0.4.7",
  "hkdf",
@@ -1531,7 +1540,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "idna",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "ipnetwork",
  "k256",
  "lazy-regex",
@@ -1551,7 +1560,6 @@ dependencies = [
  "p384",
  "path-clean",
  "pbkdf2",
- "pin-project-lite",
  "pkcs8",
  "rand 0.8.5",
  "regex",
@@ -1604,11 +1612,11 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.206.0"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c25ffa9d088ea00748dbef870bba110ac22ebf8cf7b2e9eb288409c5d852af3"
+checksum = "c2d328067139909aa81522a5d90f119368b541fbddd73ab630e4d9f777865f0d"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "proc-macro-rules",
  "proc-macro2",
  "quote",
@@ -1621,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "deno_os"
-version = "0.3.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1354565da842e399684ff58b2e726cbf0bdbb3b52c34893eaa82724938c1a20c"
+checksum = "e8371d206f6265c4e0b74116c1a58cc8c464c45da0b43c1e8c19a911e88feb2b"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1652,7 +1660,7 @@ dependencies = [
  "deno_error",
  "deno_path_util",
  "deno_semver",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "serde",
  "serde_json",
  "sys_traits",
@@ -1662,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "deno_path_util"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420e8211aaba7fde83ccaa9a5dad855c3b940ed988d70c95159acd600a70dc87"
+checksum = "c87b8996966ae1b13ee9c20219b1d10fc53905b9570faae6adfa34614fd15224"
 dependencies = [
  "deno_error",
  "percent-encoding",
@@ -1675,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "deno_permissions"
-version = "0.45.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab67e37c20a67aec6f2f871a0fae9f3cda4adb34a868b09631063d71c19eb11"
+checksum = "abf879dff0b3de4dbcb78d6dda3a55e711369d5b9f479270a82853ef106c4176"
 dependencies = [
  "capacity_builder 0.5.0",
  "deno_core",
@@ -1696,15 +1704,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "deno_resolver"
-version = "0.17.0"
+name = "deno_process"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9af8141afd7bc6c290ddae4c27acf78e59dd93c27313d54ed72e70f8fa19bb"
+checksum = "700f8a2c9d369e7035e693f26a671489a73724450cbbc0a1e32f3966ef2f21fb"
+dependencies = [
+ "deno_core",
+ "deno_error",
+ "deno_fs",
+ "deno_io",
+ "deno_os",
+ "deno_path_util",
+ "deno_permissions",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "serde",
+ "simd-json",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tokio",
+ "which",
+ "winapi",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "deno_resolver"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c4ceec7b6e22344047b8a5577bb8239dc0a99884c25c1fa7d8611f4c3ed28b"
 dependencies = [
  "anyhow",
+ "async-once-cell",
  "async-trait",
  "base32",
  "boxed_error",
+ "dashmap",
  "deno_cache_dir",
  "deno_config",
  "deno_error",
@@ -1713,8 +1752,11 @@ dependencies = [
  "deno_package_json",
  "deno_path_util",
  "deno_semver",
+ "deno_terminal",
+ "futures",
  "log",
  "node_resolver",
+ "once_cell",
  "parking_lot",
  "sys_traits",
  "thiserror 2.0.12",
@@ -1739,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "deno_runtime"
-version = "0.194.0"
+version = "0.198.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e5b199a2e6f0674ed01eb4422c0bb10b41f222ee58f6e36183af104bd664e1"
+checksum = "26a54d54ca920e5256c1e910c7574787d009a34afd41b20ad250278bb1aea290"
 dependencies = [
  "color-print",
  "deno_ast",
@@ -1765,6 +1807,7 @@ dependencies = [
  "deno_os",
  "deno_path_util",
  "deno_permissions",
+ "deno_process",
  "deno_resolver",
  "deno_telemetry",
  "deno_terminal",
@@ -1778,7 +1821,6 @@ dependencies = [
  "dlopen2 0.6.1",
  "encoding_rs",
  "fastwebsockets",
- "flate2",
  "http 1.2.0",
  "http-body-util",
  "hyper 0.14.32",
@@ -1827,15 +1869,17 @@ dependencies = [
 
 [[package]]
 name = "deno_telemetry"
-version = "0.8.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6893c3d9a7713f4519dd7f4ebbb6086a85c26b35ec0853123a32e20826c6bc5"
+checksum = "d73802ee27361bbb6c0e3c04a799b39f458afbed1972c4aff0867420d1c36fdb"
 dependencies = [
  "async-trait",
  "deno_core",
  "deno_error",
+ "deno_tls",
  "http-body-util",
  "hyper 1.6.0",
+ "hyper-rustls",
  "hyper-util",
  "log",
  "once_cell",
@@ -1862,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "deno_tls"
-version = "0.173.0"
+version = "0.177.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab6d709ad65f15dc67d35db5279e6c5f85a5c313e25511a2f26ccdc0af6d9e8"
+checksum = "a1e3ceb2be448150d8214e8fc454c947e0ea94f6ce16556544f05a67ad5a16b8"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1892,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.186.0"
+version = "0.190.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92bdf326cfe99a9543a6cf84d9580f3da4dfcf2773a7da297a850741be115e6d"
+checksum = "d79e743ad841f7826d46c6944580f5ba665fe9ab4c31a68c4eed8b5a78225da3"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1904,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.217.0"
+version = "0.221.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029c29e990f2809f48e6378cc44d28753623e75352a4a1ceff39c058353543f8"
+checksum = "8041ba73bb2f238c61b5e4ed341d2fe1f9464a71115a240ab3390480b3c10e12"
 dependencies = [
  "async-trait",
  "base64-simd 0.8.0",
@@ -1925,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "deno_webgpu"
-version = "0.153.0"
+version = "0.157.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae088970a5d8241e7df9587d7b9bff2ff16ec73d254668b7a8377bf7130c109"
+checksum = "4077584c0ccfde0737e576c396bbf1645f25ed0ebf4f44543e0ad13729285cf3"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1941,18 +1985,18 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.186.0"
+version = "0.190.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c82f6f396ba26693a513279a765e1481f4965e7b09d648d67b2189ffba24dd"
+checksum = "c4ff81a990196bf3a80fe5d339b4eb8b411ef17634d60d399a63bae6e71a37c9"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_websocket"
-version = "0.191.0"
+version = "0.195.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51742f4142673d95a1eb440a21ed5d61d8662861ca8c7be9ea6c4daa56717691"
+checksum = "2ad15c3856dd1748f9a36102e90b4e345e40d7d64a9bf6672d584201e1fded28"
 dependencies = [
  "bytes",
  "deno_core",
@@ -1975,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "deno_webstorage"
-version = "0.181.0"
+version = "0.185.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a66572a9cb12a8219b99dfbb2a8e057182919e79450a35c5adbec041b19ff71"
+checksum = "079dc4f6ce91f53bb848bad8d743dc20d16ca44cbed3425531cf5d922b1a45bc"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2374,33 +2418,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2920,7 +2943,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2939,7 +2962,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -3018,9 +3041,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -3489,7 +3512,7 @@ checksum = "1215d4d92511fbbdaea50e750e91f2429598ef817f02b579158e92803b52c00a"
 dependencies = [
  "boxed_error",
  "deno_error",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "log",
  "percent-encoding",
  "serde",
@@ -3510,9 +3533,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -3750,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libffi"
@@ -4054,9 +4077,9 @@ checksum = "b52c1b33ff98142aecea13138bd399b68aa7ab5d9546c300988c345004001eea"
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "naga"
@@ -4069,7 +4092,7 @@ dependencies = [
  "bitflags 2.8.0",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "log",
  "num-traits",
  "rustc-hash 1.1.0",
@@ -4082,9 +4105,9 @@ dependencies = [
 
 [[package]]
 name = "napi_sym"
-version = "0.116.0"
+version = "0.120.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1e7f8544ebb8840c82bf6de257df84b16570543f987cad40ae6da2ce698d71"
+checksum = "33a55ec137cebb7f4a594edd16157a5b9d9addf7ebd29c88198ec4e0cff2e93e"
 dependencies = [
  "quote",
  "serde",
@@ -4139,13 +4162,14 @@ dependencies = [
 
 [[package]]
 name = "node_resolver"
-version = "0.24.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d744641efa801ea0946b74a663cad853e3f4a59af46b9d020db25c356bf80db2"
+checksum = "808426e80ce77a311b24ac080caf18c23c632e035d797edb217ce74cdf6a0e71"
 dependencies = [
  "anyhow",
  "async-trait",
  "boxed_error",
+ "dashmap",
  "deno_error",
  "deno_media_type",
  "deno_package_json",
@@ -4155,10 +4179,10 @@ dependencies = [
  "once_cell",
  "path-clean",
  "regex",
+ "serde",
  "serde_json",
  "sys_traits",
  "thiserror 2.0.12",
- "tokio",
  "url",
 ]
 
@@ -4288,9 +4312,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -4598,7 +4622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
 ]
 
 [[package]]
@@ -4900,9 +4924,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
 ]
@@ -5330,7 +5354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.8.0",
- "errno 0.3.10",
+ "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
@@ -5635,7 +5659,7 @@ version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "itoa",
  "memchr",
  "ryu",
@@ -5644,9 +5668,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.239.0"
+version = "0.245.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3caa6d882827148e5d9052d9d8d6d1c9d6ad426ed00cab46cafb8c07a0e7126a"
+checksum = "945f93c91e0c7e4799b5fefff076756141aae92e262c4dc4833310dd3d2d845e"
 dependencies = [
  "deno_error",
  "num-bigint",
@@ -5819,9 +5843,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smartstring"
@@ -5865,17 +5889,16 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "9.1.2"
+version = "9.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c4ea7042fd1a155ad95335b5d505ab00d5124ea0332a06c8390d200bb1a76a"
+checksum = "314d62a489431668f719ada776ca1d49b924db951b7450f8974c9ae51ab05ad7"
 dependencies = [
- "base64-simd 0.7.0",
+ "base64-simd 0.8.0",
  "bitvec",
  "data-encoding",
  "debugid",
  "if_chain",
- "rustc-hash 1.1.0",
- "rustc_version 0.2.3",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "unicode-id-start",
@@ -5921,15 +5944,15 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stacker"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601f9201feb9b09c00266478bf459952b9ef9a6b94edb2f21eba14ab681a60a9"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6040,7 +6063,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "siphasher 0.3.11",
- "sourcemap 9.1.2",
+ "sourcemap 9.3.2",
  "swc_allocator",
  "swc_atoms",
  "swc_eq_ignore_macros",
@@ -6057,7 +6080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4740e53eaf68b101203c1df0937d5161a29f3c13bceed0836ddfe245b72dd000"
 dependencies = [
  "anyhow",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "serde",
  "serde_json",
  "swc_cached",
@@ -6104,7 +6127,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "serde",
- "sourcemap 9.1.2",
+ "sourcemap 9.3.2",
  "swc_allocator",
  "swc_atoms",
  "swc_common",
@@ -6169,7 +6192,7 @@ checksum = "65f21494e75d0bd8ef42010b47cabab9caaed8f2207570e809f6f4eb51a710d1"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.8.0",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "once_cell",
  "phf",
  "rustc-hash 1.1.0",
@@ -6238,7 +6261,7 @@ checksum = "76c76d8b9792ce51401d38da0fa62158d61f6d80d16d68fe5b03ce4bf5fba383"
 dependencies = [
  "base64 0.21.7",
  "dashmap",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "once_cell",
  "serde",
  "sha1",
@@ -6278,7 +6301,7 @@ version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029eec7dd485923a75b5a45befd04510288870250270292fc2c1b3a9e7547408"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "num_cpus",
  "once_cell",
  "rustc-hash 1.1.0",
@@ -6823,9 +6846,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6903,9 +6926,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-id"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10103c57044730945224467c09f71a4db0071c123a0648cc3e818913bde6b561"
+checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
 
 [[package]]
 name = "unicode-id-start"
@@ -7036,7 +7059,7 @@ checksum = "97599c400fc79925922b58303e98fcb8fa88f573379a08ddb652e72cbd2e70f6"
 dependencies = [
  "bitflags 2.8.0",
  "encoding_rs",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "num-bigint",
  "serde",
  "thiserror 1.0.69",
@@ -7237,7 +7260,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "document-features",
- "indexmap 2.7.1",
+ "indexmap 2.11.1",
  "log",
  "naga",
  "once_cell",

--- a/native/deno_rider/Cargo.toml
+++ b/native/deno_rider/Cargo.toml
@@ -1,11 +1,11 @@
 [dependencies]
-deno_core = "0.330.0"
-deno_fs = "0.96.0"
-deno_resolver = "0.17.0"
-deno_runtime = "0.194.0"
+deno_core = "0.336.0"
+deno_fs = "0.100.0"
+deno_resolver = "0.21.0"
+deno_runtime = { version = "0.198.0", features = ["transpile"] }
 rustler = "0.36.0"
 serde_json = "1.0.133"
-serde_v8 = "0.239.0"
+serde_v8 = "0.245.0"
 slab = "0.4.9"
 sys_traits = "0.1.7"
 tokio = "1.41.1"


### PR DESCRIPTION
Upgrades the `deno_runtime` library to version `0.198.0`, fixing CVE-2025-24015 (CVSS 7.7 HIGH).

Newer versions of `deno_runtime` are available, but the upgrade is not yet possible, as `deno_runtime ≥ 0.200.0` depends on `v8 ≥ 134.0`, which from this version onward is incompatible with shared library builds (being addressed on denoland/rusty_v8#1970 + denoland/v8#20).

Adds Dependabot config to track mix, cargo, and GitHub Actions updates automatically.